### PR TITLE
Support new css whitespace color syntax

### DIFF
--- a/src/strategies/functions.js
+++ b/src/strategies/functions.js
@@ -1,4 +1,4 @@
-const colorFunctions = /((rgb|hsl)a?\([\d]{1,3}%?,\s*[\d]{1,3}%?,\s*[\d]{1,3}%?(,\s*\d?\.?\d+)?\))/gi;
+const colorFunctions = /((rgb|hsl)a?\([\d]{1,3}%?(,| )\s*[\d]{1,3}%?(,| )\s*[\d]{1,3}%?((,| )\s*\d?\.?\d+)?\))/gi;
 
 /**
  * @export


### PR DESCRIPTION
```css
rgb(30 144 255)
```
That is valid css. The commas are no longer required. Refer to "whitespace syntax" example on the [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).

However, this extension doesn't highlight colors in this format. This PR adds support therefor.