### PR TITLE
Fix computation of contrast ratio to follow WCAG 2.0 guidelines

### DIFF
--- a/src/lib/dynamic-contrast.js
+++ b/src/lib/dynamic-contrast.js
@@ -1,7 +1,7 @@
 // getColorContrast
 //     Return suggested contrast grey scale color for the color (hex/rgba) given.
-//     Takes advantage of YIQ: https://en.wikipedia.org/wiki/YIQ
-//     Inspired by: http://24ways.org/2010/calculating-color-contrast/
+//     Uses the definitions of relative luminance and contrast ratio from
+//     WCAG 2.0: https://www.w3.org/TR/WCAG20
 //
 // @param color string A valid hex or rgb value, examples:
 //                         #000, #000000, 000, 000000
@@ -16,7 +16,7 @@ export function getColorContrast(color) {
     hexExp = /^(?:#)|([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/igm;
   let rgb = color.match(rgbExp),
     hex = color.match(hexExp),
-    r, g, b, yiq;
+    r, g, b;
   if (rgb) {
     r = parseInt(rgb[1], 10);
     g = parseInt(rgb[2], 10);
@@ -43,13 +43,114 @@ export function getColorContrast(color) {
       return '#000000';
     }
   }
-  yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
-  if (yiq >= 128) {
-    yiq -= 128;
+  // The color with the maximum contrast ratio to our input color is guaranteed
+  // to either be white or black, so we just check both and pick whichever has
+  // a higher contrast ratio.
+
+  let luminance = relativeLuminance(r, g, b);
+
+  // This is equivalent to `relativeLuminance(255, 255, 255)` (by definition).
+  let luminanceWhite = 1.0;
+  // This is equivalent to `relativeLuminance(0, 0, 0)` (by definition).
+  let luminanceBlack = 0.0;
+
+  let contrastWhite = contrastRatio(luminance, luminanceWhite);
+  let contrastBlack = contrastRatio(luminance, luminanceBlack);
+  if (contrastWhite > contrastBlack) {
+    return '#FFFFFF';
   } else {
-    yiq += 128;
+    return '#000000';
   }
-  color = yiq << 16 | yiq << 8 | yiq;
-  color = '#' + ('00000' + (color | 0).toString(16)).substr(-6);
-  return color;
 }
+
+// Note: the rest of this module contains unexported helper functions.
+
+/**
+ * Compute the contrast ratio between two relative luminances, using the
+ * algorithm from WCAG 2.0: <https://www.w3.org/TR/WCAG20/#contrast-ratiodef>
+ *
+ * Note that the order of the arguments does not matter. In other words, if `a`
+ * and `b` are valid inputs, then `contrastRatio(a, b) === contrastRatio(b, a)`.
+ *
+ * @param l1 number  The relative luminance of the first color -- a number
+ *                   between 0.0 and 1.0 (inclusive), which should be produced
+ *                   by the `relativeLuminance` function.
+ * @param l2 number  The relative luminance of the second color -- a number
+ *                   between 0.0 and 1.0 (inclusive), which is expected to have
+ *                   been produced by the `relativeLuminance` function.
+ *
+ * @returns  number  The contrast ratio between the input colors. Assuming the
+ *                   inputs were in the correct range, this will be a number
+ *                   between 1.0 and 21.0 (inclusive).
+ */
+function contrastRatio(l1, l2) {
+  // Note: the denominator of the contrast ratio must be the darker (e.g. lower
+  // relative luminance) color.
+  if (l2 < l1) {
+    return (0.05 + l1) / (0.05 + l2);
+  } else {
+    return (0.05 + l2) / (0.05 + l1);
+  }
+}
+
+/**
+ * Compute the relative luminance of a color, using the algorithm from WCAG 2.0
+ * <https://www.w3.org/TR/WCAG20/#relativeluminancedef>.
+ *
+ * All three color components used as input should be integers between 0 and 255
+ * inclusive, and are assumed to be in the sRGB color space -- typical for
+ * source code constants, especially ones using CSS syntax, as sRGB is the
+ * default color space on the web.
+ *
+ * (Note: it's overwhelmingly likely that even if the true color space of the
+ * color is *not* sRGB, that it still has an sRGB-style gamma curve, if not a
+ * fully sRGB-compatible one, in which case the result of this function will
+ * still be reasonable)
+ *
+ * @param r8 number  The red component, as an 8-bit integer
+ * @param g8 number  The green component, as an 8-bit integer
+ * @param b8 number  The blue component, as an 8-bit integer
+ *
+ * @returns  number  The relative luminance of the color, a number between 0.0
+ *                   and 1.0 (inclusive).
+ */
+function relativeLuminance(r8, g8, b8) {
+  const bigR = srgb8ToLinear(r8);
+  const bigG = srgb8ToLinear(g8);
+  const bigB = srgb8ToLinear(b8);
+  return 0.2126 * bigR + 0.7152 * bigG + 0.0722 * bigB;
+}
+
+/**
+ * Convert an 8-bit color component from sRGB space (the default web color
+ * space) into the linear RGB color space.
+ *
+ * This is a helper function for `relativeLuminance`, and at the moment isn't
+ * needed except as part of calling that function.
+ *
+ * @param c8 number  An 8-bit integer color channel in the sRGB color space. In
+ *                   other words, a number between 0 and 255 (inclusive).
+ *                   Anything outside this range will be clamped and truncated.
+ *
+ * @returns  number  The value of the channel in a linear RGB color space -- a
+ *                   number between 0.0 and 1.0, inclusive.
+ */
+const srgb8ToLinear = (function() {
+  // There are only 256 possible different input values (0 <= input <= 255),
+  // so we just use a lookup table, which to avoid repeating the (somewhat
+  // costly) computation 3 times for each input.
+  const srgbLookupTable = new Float64Array(256);
+  for (let i = 0; i < 256; ++i) {
+    const c = i / 255.0;
+    srgbLookupTable[i] = (c <= 0.04045)
+      ? c / 12.92
+      : Math.pow((c + 0.055) / 1.055, 2.4);
+  }
+
+  return function srgb8ToLinear(c8) {
+    // Input should be an integer between 0 and 255 already, but clamp if
+    // for some reason it is not.
+    const index = Math.min(Math.max(c8, 0), 255) & 0xff;
+    return srgbLookupTable[index];
+  };
+}());


### PR DESCRIPTION
In particular, the issue that drove me to fix this is below.

Before: <img width="168" alt="Before" src="https://user-images.githubusercontent.com/860665/124203869-849e9d80-da92-11eb-8d1d-839cfe171818.png">

After: <img width="168" alt="After" src="https://user-images.githubusercontent.com/860665/124203854-7e102600-da92-11eb-8b13-953ae2d358ac.png">

(Ah, much better)

Anyway, the previous computation was wrong in a few ways, although most of them are due to the spec it's derived from (the old W3C AERT spec) being vague (in particular, it leaves out the necessary gamma-correction step).

Anyway, there's a newer spec that is extremely explicit about the color spaces (and thus, the gamma-correction operation needed), and it's also better for color-blind users (admittedly... there may not be many of them using this addon) so I used some code for it that I had [lying around](https://gist.github.com/thomcc/4d2a62b5e2633289c0034082fccda182)<sup>1</sup>.

Anyway, I just used that with updated comments, to hopefully make it clear what the parts are doing, and etc. If you'd rather not have the code in question in your project, I can publish it as a package instead, or look harder for something correct.

Closes #111.

P.S. To actually test this out I had to fix another couple issues, which will have an incoming PR, (separated, since they might have been due to my own confusion).

---

1: Bugs in this sort of code are a personal peeve of mine, and in the past I failed to find a good/efficient implementation of the contrast computation on NPM, so I wrote that one. I never published it to NPM, mostly since I'm lazy and don't write JS regularly anymore. I was going to do it now, although publishing a package and immediately PRing someone to use it seems sketchy.