### PR TITLE
fix: silence document version change

### DIFF
--- a/src/color-highlight.js
+++ b/src/color-highlight.js
@@ -99,7 +99,7 @@ export class DocumentHighlight {
 
       const actualVersion = this.document.version.toString();
       if (actualVersion !== version) {
-        throw new Error('Document version already has changed');
+        return;
       }
 
       const colorRanges = groupByColor(concatAll(result));


### PR DESCRIPTION
Quoting the reason from [here](https://github.com/enyancc/vscode-ext-color-highlight/issues/44#issuecomment-877717215):

> > I think it just prevents some code from running unnecessarily.
>
> @ferretwithaberet If that's all it does, perhaps just change ` throw new Error('Document version already has changed');` to `return;`? When developing extensions, I'm constantly seeing this message.

Fixes #44.
