### PR TITLE
Fix findHex() to correctly handle hex color codes which include alpha…

### DIFF
--- a/src/strategies/hex.js
+++ b/src/strategies/hex.js
@@ -18,7 +18,17 @@ export async function findHex(text) {
   while (match !== null) {
     const firstChar = match[0][0];
     const matchedColor = match[1];
-    const matchedHex = '#' + match[2];
+    // Here we check for possibility of hex codes with ALPHA (0xaabbcc vs 0xffaabbcc) 
+    // or (0xF0FF vs 0x0FF)  
+    // and remove the the alpha part (the first digit in 4 digit hex or first 2 digits
+    // in an 8 digit hex)
+    // Otherwise the color we capture gets interpreted incorrectly by Color() below.
+    //   The two hex codes above SHOULD BE the same color if the corrected version of the extension is running.
+    const matchedHex = '#' + 
+                      (match[2].length==4 ? 
+                          (match[2].substring(1, 4)) : 
+                          ( (match[2].length==8) ? match[2].substring(2, 8) : match[2])
+                      );
     const start = match.index + (match[0].length - matchedColor.length);
     const end = colorHex.lastIndex;
 


### PR DESCRIPTION
… digits (either 4 digit or 8 digit hex codes)- and IGNORE them.

The extension previously would create the incorrect colors by considering the ALPHA digits ignoring the BLUE digits.
The comment in the source code shows hex codes with and without the alpha digits, and you can see that the extension creates different colors for these without this fix.