### PR TITLE
Add options matchHEX3 and matchHEX4 to control HEX highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [2.7.0]
+
+### Added
+
+- "matchHEX3" option to Highlight HEX 3-byte/nibble values
+- "matchHEX4" option to Highlight HEX 4-byte/nibble values (Disabled by default)
 ## [2.6.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "color-highlight",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "color-highlight",
-      "version": "2.5.0",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "color-highlight",
   "displayName": "Color Highlight",
   "description": "Highlight web colors in your editor",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "publisher": "naumovs",
   "license": "GPL-3.0",
   "engines": {
@@ -62,6 +62,16 @@
         "color-highlight.useARGB": {
           "default": false,
           "description": "Highlight HEX values using ARGB instead of RGBA (default)",
+          "type": "boolean"
+        },
+        "color-highlight.matchHEX3": {
+          "default": true,
+          "description": "Highlight HEX 3-byte/nibble values",
+          "type": "boolean"
+        },
+        "color-highlight.matchHEX4": {
+          "default": false,
+          "description": "Highlight HEX 4-byte/nibble values",
           "type": "boolean"
         },
         "color-highlight.matchRgbWithNoFunction": {

--- a/src/color-highlight.js
+++ b/src/color-highlight.js
@@ -34,9 +34,9 @@ export class DocumentHighlight {
     this.strategies = [findFn, findHwb];
 
     if (viewConfig.useARGB == true) {
-      this.strategies.push(findHexARGB);
+      this.strategies.push((text) => findHexARGB(text, viewConfig.matchHEX3, viewConfig.matchHEX4));
     } else {
-      this.strategies.push(findHexRGBA);
+      this.strategies.push((text) => findHexRGBA(text, viewConfig.matchHEX3, viewConfig.matchHEX4));
     }
 
     if (colorWordsLanguages.indexOf(document.languageId) > -1 || viewConfig.matchWords) {

--- a/src/strategies/hex.js
+++ b/src/strategies/hex.js
@@ -3,6 +3,12 @@ import Color from 'color';
 const colorHex =
   /.?((?:\#|\b0x)([a-f0-9]{6}([a-f0-9]{2})?|[a-f0-9]{3}([a-f0-9]{1})?))\b/gi;
 
+const colorHex3 =
+  /.?((?:\#|\b0x)([a-f0-9]{6}|[a-f0-9]{3}))\b/gi;
+
+const colorHex4 =
+  /.?((?:\#|\b0x)([a-f0-9]{8}|[a-f0-9]{4}))\b/gi;
+
 /**
  * @export
  * @param {string} text
@@ -12,22 +18,36 @@ const colorHex =
  *  color: string
  * }}
  */
-function findHex(text, useARGB) {
-  let match = colorHex.exec(text);
+function findHex(text, useARGB, matchHEX3, matchHEX4) {
+  if (matchHEX3 == false && matchHEX4 == false) {
+    return [];
+  }
+
+  let reHex;
+  if (matchHEX3 == true && matchHEX4 == true) {
+    reHex = colorHex;
+  }
+  if (matchHEX3 == true) {
+    reHex = colorHex3;
+  }
+  else {
+    reHex = colorHex4;
+  }
+  let match = reHex.exec(text);
   let result = [];
 
   while (match !== null) {
     const firstChar = match[0][0];
     const matchedColor = match[1];
     const start = match.index + (match[0].length - matchedColor.length);
-    const end = colorHex.lastIndex;
+    const end = reHex.lastIndex;
     let matchedHex = '#' + match[2];
 
     // Check the symbol before the color match, and try to avoid coloring in the
     // contexts that are not relevant
     // https://github.com/sergiirocks/vscode-ext-color-highlight/issues/25
     if (firstChar.length && /\w/.test(firstChar)) {
-      match = colorHex.exec(text);
+      match = reHex.exec(text);
       continue;
     }
 
@@ -54,7 +74,7 @@ function findHex(text, useARGB) {
       });
     } catch (e) {}
 
-    match = colorHex.exec(text);
+    match = reHex.exec(text);
   }
 
   return result;
@@ -69,8 +89,8 @@ function findHex(text, useARGB) {
  *  color: string
  * }}
  */
-export async function findHexARGB(text) {
-  return findHex(text, true);
+export async function findHexARGB(text, matchHEX3 = true, matchHEX4 = true) {
+  return findHex(text, true, matchHEX3, matchHEX4);
 }
 
 /**
@@ -82,6 +102,6 @@ export async function findHexARGB(text) {
  *  color: string
  * }}
  */
-export async function findHexRGBA(text) {
-  return findHex(text, false);
+export async function findHexRGBA(text, matchHEX3 = true, matchHEX4 = true) {
+  return findHex(text, false, matchHEX3, matchHEX4);
 }


### PR DESCRIPTION
In most cases a 2- or 4-byte hex value does NOT represent an RGBA color value.
With the new matchHEX3 and matchHEX4 options this can be configured.
- Option matchHEX3 is On by default and matches 0xaabbcc and 0xabc.
- Option matchHEX4 is Off by default and matches 0xaabbccdd and 0xabcd.