### PR TITLE
Feature: add HSL Without Function + fix RGB double matching + support floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 ## [Unreleased]
 
+## [2.7.0]
+
+### Added
+
+- Support for HSL format without `hsl()` and configuration options for it (Disabled by default)
+- Support for floating-point numbers in hsl and rgb (like `343.2 15.4% 34.4%` or `rgb(100.4, 89.4%, 66.4%)`) - it's quite common in Tailwind
+
+### Fixed
+- Fix double highlighting for function `rgb()` when `rgbWithNoFunction` is enabled
+
 ## [2.6.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "color-highlight",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "color-highlight",
-      "version": "2.5.0",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "color-highlight",
   "displayName": "Color Highlight",
   "description": "Highlight web colors in your editor",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "publisher": "naumovs",
   "license": "GPL-3.0",
   "engines": {
@@ -70,6 +70,18 @@
           "type": "boolean"
         },
         "color-highlight.rgbWithNoFunctionLanguages": {
+          "default": [
+            "*"
+          ],
+          "description": "An array of language ids which should be highlighted by Color Highlight with the rgbWithNoFunction pattern. \"*\" to trigger on any language; Prepend language id with \"!\" to exclude the language (i.e \"!typescript\", \"!javascript\")",
+          "type": "array"
+        },
+        "color-highlight.matchHslWithNoFunction": {
+          "default": false,
+          "description": "Highlight hsl without functions like hsl() ('255, 100%, 80%', [255, 100%, 80%], '255 100% 80%', etc.)",
+          "type": "boolean"
+        },
+        "color-highlight.hslWithNoFunctionLanguages": {
           "default": [
             "*"
           ],

--- a/src/color-highlight.js
+++ b/src/color-highlight.js
@@ -10,6 +10,7 @@ import { findStylVars } from './strategies/styl-vars';
 import { findCssVars } from './strategies/css-vars';
 import { findFn } from './strategies/functions';
 import { findRgbNoFn } from './strategies/rgbWithoutFunction';
+import { findHslNoFn } from "./strategies/hslWithoutFunction";
 import { findHexARGB, findHexRGBA } from './strategies/hex';
 import { findHwb } from './strategies/hwb';
 import { findWords } from './strategies/words';
@@ -59,6 +60,24 @@ export class DocumentHighlight {
       }
 
       if (isValid) this.strategies.push(findRgbNoFn);
+    }
+
+    if (viewConfig.matchHslWithNoFunction) {
+      let isValid = false;
+
+      if (viewConfig.hslWithNoFunctionLanguages.indexOf('*') > -1) {
+        isValid = true;
+      }
+
+      if (viewConfig.hslWithNoFunctionLanguages.indexOf(document.languageId) > -1) {
+        isValid = true;
+      }
+
+      if (viewConfig.hslWithNoFunctionLanguages.indexOf(`!${document.languageId}`) > -1) {
+        isValid = false;
+      }
+
+      if (isValid) this.strategies.push(findHslNoFn);
     }
 
     switch (document.languageId) {

--- a/src/color-highlight.js
+++ b/src/color-highlight.js
@@ -10,7 +10,7 @@ import { findStylVars } from './strategies/styl-vars';
 import { findCssVars } from './strategies/css-vars';
 import { findFn } from './strategies/functions';
 import { findRgbNoFn } from './strategies/rgbWithoutFunction';
-import { findHslNoFn } from "./strategies/hslWithoutFunction";
+import { findHslNoFn } from './strategies/hslWithoutFunction';
 import { findHexARGB, findHexRGBA } from './strategies/hex';
 import { findHwb } from './strategies/hwb';
 import { findWords } from './strategies/words';

--- a/src/strategies/hslWithoutFunction.js
+++ b/src/strategies/hslWithoutFunction.js
@@ -1,0 +1,45 @@
+import Color from 'color';
+
+// Using [^\S\n] to avoid matching colors between lines. Using (?:;| |$) to avoid double matching with rgb() function
+const colorHsl =
+  /([.\d]{1,5})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*([.\d]{1,5}%)[^\S\n]*\k<commaOrSpace>[^\S\n]*([.\d]{1,5}%)(?:;| |$)/g;
+
+/**
+ * @export
+ * @param {string} text
+ * @returns {{
+ *  start: number,
+ *  end: number,
+ *  color: string
+ * }}
+ */
+export async function findHslNoFn(text) {
+  let match = colorHsl.exec(text);
+  let result = [];
+
+  while (match !== null) {
+    const [matchedColor, hue, , saturation, lightness] = match;
+    const start = match.index + (match[0].length - matchedColor.length);
+    const end = colorHsl.lastIndex;
+
+    try {
+      const color = Color.hsl(
+        parseInt(hue),
+        parseInt(saturation),
+        parseInt(lightness)
+      ).string();
+
+      result.push({
+        start,
+        end,
+        color,
+      });
+    } catch (e) {
+      console.error(e);
+    }
+
+    match = colorHsl.exec(text);
+  }
+
+  return result;
+}

--- a/src/strategies/rgbWithoutFunction.js
+++ b/src/strategies/rgbWithoutFunction.js
@@ -1,7 +1,7 @@
 import Color from 'color';
 
-// Using [^\S\n] to avoid matching colors between lines
-const colorRgb = /(\d{1,3})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*(\d{1,3})[^\S\n]*\k<commaOrSpace>[^\S\n]*(\d{1,3})/g;
+// Using [^\S\n] to avoid matching colors between lines. Using (?:;| |$) to avoid double matching with rgb() function
+const colorRgb = /([.\d]{1,5})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*([.\d]{1,5})[^\S\n]*\k<commaOrSpace>[^\S\n]*([.\d]{1,5})(?:;| |$)/g;
 
 /**
  * @export


### PR DESCRIPTION
Hey :)

First, many thanks for your plugin! It's exactly what I needed.
I appreciate the way you organized the files, it was very easy to understand how it works and add a new functionality.

## Motivation for this PR

Many people use Tailwind right now, with CSS variables containing HSL color format without function name, like this:
```css
--navy: 208 100% 25%;
```

It's a huge pain for many that there is no plugin supporting this format, here you can find some complaints:
- https://github.com/tailwindlabs/tailwindcss-intellisense/issues/409
- https://github.com/shadcn-ui/ui/issues/199#issuecomment-1602739537

## My changes

- replication of your `rgbWithoutFunction` logic as new `hslWithoutFunction` + configs
- support for floating-point numbers in HSL and RGB (it's quite common in Tailwind, probably because of automation)
- bugfix for double-matching when hsl/rgb without function is enabled - I had double "dot" (color square) for `rgb(...)` and `hsl(...)` with function (one inside brackets, and one after brackets). If you use a "background" color you may not notice it.
- Changelog and version update (in the `lock` file is 2.5.0 but I guess it should be 2.6.0 so the new version is `2.7.0` ?)

Here is how it looks after my changes:
![image](https://github.com/enyancc/vscode-ext-color-highlight/assets/28517564/dc2f3f34-f8d8-41b6-8562-cd19873324f1)

And here is a link to download the packaged VSIX file:
https://we.tl/t-VHTnVChsMR

To install it we can just go to "Extension", click three dots icon (up-right corner of extensions), and select `Install from VSIX...` or with CLI: `code --install-extension myextension.vsix`.

## How to test

I'm new to VSCode plugins so maybe this is not the best way to test it, but maybe this will be helpful:

- either make a new build on my branch (but there are version issues, so I had to use `nvm` and switch to `Node 16.14` to make it work - the package needs updates, but it's out of the scope of this PR, I may start a new one if you want)
- or just install my VSIX file (I guess you have to uninstall your plugin first?)
- you can test on some variables like here:

```css
    --navy: 208 100% 25%;
    --red: 360 87% 44%;
    --redRGB: 255, 0, 0;
    --test: hsl(360 87% 44%);
```

Here you can test my RegEx and modify it if you want:
- https://regex101.com/r/1LyWW4/1

If the link expired:
Regex `([.\d]{1,5})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*([.\d]{1,5}%)[^\S\n]*\k<commaOrSpace>[^\S\n]*([.\d]{1,5}%)(?:;| |$)`

My testing values:
```
--navy: 208 100% 25%;
--dark-blue: 208, 100%, 25%;
--navy_blue: 208, 100%, 25%;
--red: 360 87% 44%;
 --foreground: 224 71.4% 4.1%
--popover-foreground: 224 71.4% 4.1%;
    --background: 224 100% 4.1%;
    --primary-foreground: 220.9 39.3% 100%;
    --secondary: 215 27.9% 16.9%;
    --secondary-foreground: 210 20% 98%;   --ring: 224 71.4% 4.1%;
    --muted-foreground: 217.9 10.6% 64.9%;
--navy: 360 100% 100%;

// correct but will fail (out of scope for the plugin):
--navy_blue: hsla(208, 100%, 25%);
--navy_blue: hsl(208, 100%, 25% / 50%);
--navy_blue: hsla(0.3turn 100% 25% / .7);
  --red: hsl(360 87% 44%);

// Should fail:
--navy: 208% 100% 25%;
--navy: 208 100 25%;
--navy: 208 100 25;
--navy: 208 dfdf100% 25%;
--navy: #00ff33;
--foreground: 224 71.4% 4.1%dsfsf
--max-width: 1100px;
--radius: 0.5rem;
h1:hover { weight: bold };
```

## Other suggestions

- I would change `activationEvents` option in `package.json` - it's bad for performance to use `*` - IMHO it would be best to make an array of all languages/files we can expect color definitions. Now it's triggering EVERYWHERE, terminal, sidebar, everywhere. The minimum option is to set `onStartupFinished` to don't slow down starting of VSCode.
   - onLanguage: https://code.visualstudio.com/api/references/activation-events#onLanguage
   - List of langages: https://code.visualstudio.com/docs/languages/identifiers
   - onStartupFinis: https://code.visualstudio.com/api/references/activation-events#onStartupFinished
   - not recommended startup: https://code.visualstudio.com/api/references/activation-events#Start-up
- I would update packages, for example `vscode` is deprecated, we should use `@types/vscode` now, and if you plan to use tests then vscode electron tests are a new way to do this. It should fix issues on build and let us use Node 18
- personally, I would set the `dot after` (or `square after`?) option as default, it's less invasive and looks better with build-in VSCode CSS color feature (the square on the left of the color)
- I would also disable colors on the scrollbar by default, it's too much for me ;)

## Separate Extension for Tailwind

Do you mind if I would create a separate extension named "Color Highlight Tailwind"?
With full credentials and links to your extension of course.

I guess many people using Tailwind would like to use it only for CSS variables without function names, and/or only in CSS files.
It would be much better for performance.

Do you mind if I create this minimalistic version based on your extension (by just removing unnecessary parts)?
I have already created a Regex for this ;) https://regex101.com/r/h1nY7R/1

## Unapprove?

If you would not approve this PR for any reason I would really like to create a separate forked plugin - we really need that plugin for Tailwind :)