### PR TITLE
fix: enable floating point value display

### DIFF
--- a/src/lib/dynamic-contrast.js
+++ b/src/lib/dynamic-contrast.js
@@ -12,15 +12,16 @@
 import webColors from 'color-name';
 
 export function getColorContrast(color) {
-  const rgbExp = /^rgba?[\s+]?\(\s*([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*,\s*([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*,\s*([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*(?:,\s*([\d.]+)\s*)?\)/im,
-    hexExp = /^(?:#)|([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/igm;
+  const rgbExp =
+      /^rgba?[\s+]?\(\s*([0-9]+(?:\.[0-9]+)?)\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*(?:,\s*([\d.]+)\s*)?\)/im,
+    hexExp = /^(?:#)|([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/gim;
   let rgb = color.match(rgbExp),
     hex = color.match(hexExp),
     r, g, b;
   if (rgb) {
-    r = parseInt(rgb[1], 10);
-    g = parseInt(rgb[2], 10);
-    b = parseInt(rgb[3], 10);
+    r = parseFloat(rgb[1]);
+    g = parseFloat(rgb[2]);
+    b = parseFloat(rgb[3]);
   } else if (hex) {
     if (hex.length > 1) {
       hex = hex[1];


### PR DESCRIPTION
### Description

Fixes an issue where the `getColorContrast()` function did not work correctly when the rgba values included decimal points.

### Problem

Including decimal points in rgba values is not correct syntax, but I have experienced situations where both the text and background turn completely black, making it difficult to verify the input values.

For example, if you incorrectly input something like `rgba(0,0,0.1)`, both the text and background turn black, rendering the values unreadable. (Attached at screenshot)

### Solution

In the `getColorContrast()` function of `dynamic-contrast.js`, I modified the `rgbExp` to accept decimal values. Additionally, I changed the calculation to use `parseFloat` instead of `parseInt` to handle these values correctly.

### Screenshot

**AS-IS**

<img width="222" alt="image" src="https://github.com/user-attachments/assets/c6fe51e9-d412-4c4f-8320-288e8e2a4d8d">

**TO-BE**

<img width="230" alt="image" src="https://github.com/user-attachments/assets/38d199cf-e987-4784-86ff-ce1c88b9eb32">

### Note

**AS-IS (tested with included `test/fixture/test.css`)**
<img width="311" alt="image" src="https://github.com/user-attachments/assets/c2c4d043-fd84-4f23-9b01-50ffc4e63e24">

**TO-BE (tested with included `test/fixture/test.css`)**
<img width="319" alt="image" src="https://github.com/user-attachments/assets/b695bb75-e166-4e2a-8f23-796bc5317718">

I have tested this change with your `test/fixture/test.css`, but If you believe this PR might cause a breaking change, it's perfectly fine not to merge it and to fix the issue in your own way.

Thank you for creating such a great extension.
