### PR TITLE
Update rgbWithoutFunction to highlight in XML files

### DIFF
--- a/src/strategies/rgbWithoutFunction.js
+++ b/src/strategies/rgbWithoutFunction.js
@@ -1,7 +1,7 @@
 import Color from 'color';
 
 // Using [^\S\n] to avoid matching colors between lines. Using (?:;| |$) to avoid double matching with rgb() function
-const colorRgb = /([.\d]{1,5})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*([.\d]{1,5})[^\S\n]*\k<commaOrSpace>[^\S\n]*([.\d]{1,5})(?=;| |$|<)/g;
+const colorRgb = /([.\d]{1,5})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*([.\d]{1,5})[^\S\n]*\k<commaOrSpace>[^\S\n]*([.\d]{1,5})(?=;| |$|<|\r)/g;
 
 /**
  * @export

--- a/src/strategies/rgbWithoutFunction.js
+++ b/src/strategies/rgbWithoutFunction.js
@@ -1,7 +1,7 @@
 import Color from 'color';
 
 // Using [^\S\n] to avoid matching colors between lines. Using (?:;| |$) to avoid double matching with rgb() function
-const colorRgb = /([.\d]{1,5})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*([.\d]{1,5})[^\S\n]*\k<commaOrSpace>[^\S\n]*([.\d]{1,5})(?:;| |$)/g;
+const colorRgb = /([.\d]{1,5})[^\S\n]*(?<commaOrSpace>[^\S\n]|,)[^\S\n]*([.\d]{1,5})[^\S\n]*\k<commaOrSpace>[^\S\n]*([.\d]{1,5})(?=;| |$|<)/g;
 
 /**
  * @export


### PR DESCRIPTION
Currently, colors in XML like `<color>123, 234, 12</color>` don't highlight. This change enables highlighting in XML files where the color string ends with a `<`

It also changes the "end" string to not highlight the trailing space or semicolon.